### PR TITLE
Puppet Inventory Service module submission

### DIFF
--- a/dm_include/dm_puppet_inventory_service/README.md
+++ b/dm_include/dm_puppet_inventory_service/README.md
@@ -1,0 +1,29 @@
+ubersmith-puppet-inventory
+==========================
+
+This is a device module which adds support for the Puppet Inventory Service to Ubersmith. Once installed, you will be able to see an output of all facts associated with a device inside of the device manager. This makes inventorying servers easy - just compare your internal record of serial numbers and configurations with the output of factor, right from the Ubersmith web interface.
+
+Installation
+------------
+
+You'll need to have Puppet installed, and activate the Puppet Inventory Service. It's very easy to do - learn more at http://docs.puppetlabs.com/guides/inventory_service.html
+
+To set up the inventory service quickly, just add:
+
+    path /facts
+    auth yes
+    method find, search
+    allow ubersmith
+
+to /etc/puppet/auth.conf on your Puppet Master, then generate a key called "ubersmith" by running `puppet cert --generate ubersmith`
+
+To install this module, just add the dm\_puppet\_inventory\_service.php file to the includes/device_modules/ directory on your Ubersmith "frontend" machine (inside of the webroot for Ubersmith).
+
+After installing the file, go to the "Setup & Admin" area of Ubersmith and click "Device Types". Now, click the "Modules" link for a device type, then "Add Module" and select "Puppet Inventory Service".
+
+On the Config tab, you'll need to enter the full URL to your Puppet Inventory Service server, which is normally https://puppet:8140/production/facts
+You can optionally enter a comma separated list of fact names that you'd like to include or exclude (to cut down on un-needed information).
+
+In the Certificate field, add the output of `cat /var/lib/puppet/ssl/private_key/ubersmith.pem /var/lib/puppet/ssl/certs/ubersmith.pem` from the Puppet Master server
+
+Once you save your changes, you can browse your devices under Device Manager and you should see a new section labeled "Puppet Inventory Service" which contains a nicely formatted list of facts for the device. If the device is not found, an error will appear in the box. Note that the module uses the value of the "label" field to query the Puppet Inventory Service - this same field is used by the built in Ubersmith Puppet Node Control module.

--- a/dm_include/dm_puppet_inventory_service/dm_puppet_inventory_service.php
+++ b/dm_include/dm_puppet_inventory_service/dm_puppet_inventory_service.php
@@ -1,0 +1,188 @@
+<?php
+
+/**
+ * Puppet Inventory Service Module
+ * 
+ * https://github.com/jasongill/ubersmith-puppet-inventory
+ * 
+ * This module will issue a query to the Puppet Inventory Service for the 
+ * configured device and return a list of information in the summary.
+ *
+ * Place this file in to
+ * include/device_modules/
+ * on your Ubersmith "frontend" server, then activate from "Device Types"
+ *
+ * @author Matt Kennedy <mkennedy@jumpline.com>
+ * @author Jason Gill <jasongill@gmail.com>
+ * @package default
+ **/
+
+class dm_puppet_inventory_service extends device_module
+{
+	/**
+	 * Device Module Title
+	 *
+	 * This function returns the title of your device module. It will be included
+	 * in the light blue title bar on the Device Manager page for your device,
+	 * as well as in the configuration drop down in the Device Types section of
+	 * 'setup & admin'.
+	 *
+	 * @return string
+	 **/
+	function title()
+	{
+		return 'Puppet Inventory Service';
+	}
+	
+	/**
+	 * Device Module Initialization
+	 *
+	 * This function will perform some basic initialization routines. In this 
+	 * example, custom data for the device is retrieved. Other useful calls
+	 * could be included in this step, if needed.
+	 * 
+	 * @return void
+	 */
+	function init($request = array())
+	{
+		if (isset($this->device)) {
+			$this->metas = device_metadata($this->device);
+		}
+	}
+	
+	/**
+	 * Device Module Summary
+	 *
+	 * This function returns a string (usually of HTML) that will be displayed
+	 * in the Device Module's 'box' on the device's Device Manager page
+	 * 
+	 * This can be used to display retrieved information, or provide a link
+	 * to a utility outside of Ubersmith, or to call some functionality within
+	 * Ubersmith.
+	 * 
+	 * @return string
+	 **/
+	function summary($request = array())
+	{
+		$this->init($request);
+		
+		$url = sprintf("%s/%s", $this->config('pis_baseurl'), $this->device['label']);
+		
+		// Get the optional fact list
+		$factstring = $this->config('pis_facts');
+		$factlist = array();
+		if($factstring) {
+			foreach(explode(',', $factstring) as $fact) {
+				array_push($factlist, trim($fact));
+			}
+		}
+		$fcount = count($factlist);
+		
+		// Get the optional fact exclusion list
+		$factstring = $this->config('pis_factexclude');
+		$excludelist = array();
+		foreach(explode(',', $factstring) as $fact) {
+			array_push($excludelist, trim($fact));
+		}
+		
+		// Put the cert into a tmp file
+		$tmpfname = tempnam("/tmp", "dm_puppent_inventory_service");
+		$handle = fopen($tmpfname, "w");
+		fwrite($handle, $this->config('pis_certificate'));
+		fclose($handle);
+
+		$curl = curl_init($url);
+		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
+		curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 0);
+		curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
+		curl_setopt($curl, CURLOPT_SSLCERT, $tmpfname);
+		curl_setopt($curl, CURLOPT_HEADER, 0);
+		$extraHeaders = array(
+                              'Accept: yaml',
+                              );
+		curl_setopt($curl, CURLOPT_HTTPHEADER, $extraHeaders);
+		
+		$response = curl_exec($curl);
+		unlink($tmpfname);
+		
+		if(curl_errno($curl)) {
+			return ("API Server connection error: " . curl_error($curl));
+		}
+		curl_close($curl);
+		
+		// Parse response into a key/value array of facts
+		$lines = explode("\n", $response);
+		$data = array();
+		
+		foreach($lines as $line) {
+			if(preg_match('/^\s+([\w_]+):\s*(.*)$/', $line, $matches)) {
+				if(!$fcount or in_array($matches[1], $factlist)) {
+					$data[$matches[1]] = $matches[2];
+				}
+			}
+		}
+		
+		// Delete anything from the exclusion list
+		foreach($excludelist as $exclude) {
+			unset($data[$exclude]);
+		}
+		
+		if(!count($data)) {
+			return $response;
+		}
+		// Sort keys and render results into an HTML table
+		$keys = array_keys($data);
+		sort($keys);
+		$returnval = "<table>";
+		foreach($keys as $key) {
+			$output = trim($data[$key], "\"");
+			$output = wordwrap($output, 50, "<br />\n", true);
+			$returnval .= "<tr onMouseOver=\"this.bgColor='#eeeeee'\" onMouseOut=\"this.bgColor='white'\"><td>$key</td><td style=\"font-family: monospace; padding-left: 15px;\">$output</td></tr>";
+		}
+		$returnval .= "</table>";
+		return $returnval;
+	}
+	
+	/**
+	 * Device Module Configuration Items
+	 *
+	 * This function returns an array of configuration options that will be 
+	 * displayed when the module is configured in the Device Types section of 
+	 * setup & admin.
+	 *
+	 * @return array
+	 **/
+	function config_items()
+	{
+		return array(
+			'pis_baseurl'	=> array(
+				'label' => uber_i18n('Puppet Inventory Service URL'),
+				'type' => 'text',
+				'size' => 35,
+				'default' => 'https://puppet:8140/production/facts',
+			),
+			'pis_facts' => array(
+				'label' => uber_i18n('Fact Names to Display (Comma separated names, blank for all)'),
+				'type' => 'text',
+				'size' => 35,
+				'default' => '',
+			),
+			'pis_factexclude' => array(
+				'label' => uber_i18n('Fact Names to Exclude (Comma separated names, blank for none)'),
+				'type' => 'text',
+				'size' => 35,
+				'default' => '',
+			),
+			'pis_certificate' => array(
+				'label' => uber_i18n('Certificate'),
+				'type' => 'textarea',
+				'rows' => 20,
+				'cols' => 35,
+				'default' => '',
+			),
+		);
+	}
+
+}
+
+// end of script


### PR DESCRIPTION
Added Puppet Inventory Service support, from https://github.com/jasongill/ubersmith-puppet-inventory

Per ticket #259461, here is a copy of our device module which can query the Puppet Inventory Service (and thus show Facter facts for servers inside the Ubersmith device manager)
